### PR TITLE
PEM-10022: add architecture manifest for keycloak

### DIFF
--- a/architecture.yaml
+++ b/architecture.yaml
@@ -1,0 +1,27 @@
+manifest_version: 1
+service: keycloak
+description: Manifesto minimo para alimentar o portal de arquitetura e a central de governanca do ecossistema Pulsus.
+owner: platform
+domain: identity
+lifecycle: production
+tier: medium
+repository:
+  name: keycloak
+  url: https://github.com/pulsus-mobi/keycloak
+runtime:
+  platform: unknown
+  language: java
+  entrypoints: []
+environments:
+  - production
+dependencies: []
+documentation:
+  readme:
+    path: README.md
+    title: README do repositorio keycloak
+    summary: Documento agregado automaticamente pelo portal de arquitetura.
+apis: []
+external_integrations: []
+events:
+  consumes: []
+  produces: []


### PR DESCRIPTION
## PEM-10022

### Objetivo
Adicionar o `architecture.yaml` minimo do repositório `keycloak` para alimentar o portal `arquitetura-staging` e a central de governança.

### Escopo
- adiciona manifesto arquitetural minimo
- referencia o README do repositório para a central do desenvolvedor
- alvo desta etapa: branch `main`

### Observações
- PR gerado como parte da frente de governança de serviços
- sem alteração de runtime de produção
- sem merge automático para evitar qualquer disparo de deploy